### PR TITLE
OpenFold Installation and DeepSpeed Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ cd openfold
 python setup.py develop
 ```
 
+Alternatively, you can install OpenFold with:
+
+```
+pip install -q git+https://github.com/asarigun/openfold.git
+```
+
 (PRs to improve this hacky workaround is welcomed!)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ jupyter
 ninja
 biotite
 git+https://github.com/webdataset/webdataset.git@5b12e0ba78bfb64741add2533c5d1e4cf088ffff
+deepspeed==0.14.4
 
 # for openfold, use this hack to get around clunky imports while
 # making sure the custom CUDA kernels used are being created: 


### PR DESCRIPTION
Installing OpenFold might be challenging for users. As an alternative, we can use this version of OpenFold without the need for local cloning.

Additionally, the old version of DeepSpeed has some issues. Upgrading to the new version should resolve all the problems.